### PR TITLE
Deprecate usage of Class::MOP::load_class

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,6 @@
+0.1.7
+  - Replace Class::MOP::load_class with Module::Runtime (Kent Fredric)
+
 0.1.6 - 2013-05-08
   - ignore_missing 1 for aliases
 

--- a/dist.ini
+++ b/dist.ini
@@ -3,7 +3,7 @@ author  = Moritz Onken
 license = BSD
 copyright_holder = Moritz Onken
 
-version = 0.1.6
+version = 0.1.7
 
 [Prereqs / TestRequires]
 File::Find = 0

--- a/dist.ini
+++ b/dist.ini
@@ -26,6 +26,7 @@ JSON = 0
 List::MoreUtils = 0
 List::Util = 0
 Module::Find = 0
+Module::Runtime = 0
 Moose = 2.02
 MooseX::Attribute::Deflator = 2.2.0
 MooseX::Attribute::Chained = 1.0.1

--- a/lib/ElasticSearchX/Model/Document/Trait/Class.pm
+++ b/lib/ElasticSearchX/Model/Document/Trait/Class.pm
@@ -31,8 +31,9 @@ has _id_attribute => ( is => 'ro', lazy_build => 1 );
 has _attribute_traits => ( is => 'ro', lazy_build => 1 );
 
 sub _build__attribute_traits {
+    require Module::Runtime;
     return { map {
-            Class::Load::load_class($_);
+            Module::Runtime::require_module($_);
             my ($name) = ( $_ =~ /::(\w+)$/ );
             lc($name) => $_
         } Module::Find::findallmod(
@@ -42,8 +43,9 @@ sub _build__attribute_traits {
 
 sub _build_set_class {
     my $self = shift;
-    my $set  = $self->name . '::Set';
-    eval { Class::MOP::load_class($set); } and return $set
+    require Module::Runtime;
+    my $set  = Module::Runtime::compose_module_name( $self->name , 'Set' );
+    eval { Module::Runtime::require_module($set); } and return $set
         or return 'ElasticSearchX::Model::Document::Set';
 }
 

--- a/lib/ElasticSearchX/Model/Index.pm
+++ b/lib/ElasticSearchX/Model/Index.pm
@@ -44,7 +44,8 @@ sub _build_types {
         Module::Find::findallmod($namespace),
         grep {/^\Q$namespace\E::/} keys %stash
     );
-    map { Class::MOP::load_class($_) } @found;
+    require Module::Runtime;
+    map { Module::Runtime::require_module($_) } @found;
     @found = grep {
         $_->isa('Moose::Object')
             && $_->does('ElasticSearchX::Model::Document::Role')
@@ -67,7 +68,8 @@ sub _build_namespace {
 sub type {
     my ( $self, $type ) = @_;
     my $class = $self->get_type($type)->set_class;
-    Class::MOP::load_class($class);
+    require Module::Runtime;
+    Module::Runtime::require_module($class);
     return $class->new(
         index => $self,
         type  => $self->get_type($type),


### PR DESCRIPTION
This method is now deprecated in Moose and warns loudly.

https://metacpan.org/pod/release/ETHER/Moose-2.1106-TRIAL/lib/Moose/Manual/Delta.pod#The-Class::Load-wrapper-functions-in-Class::MOP-have-been-deprecated
